### PR TITLE
fix data race

### DIFF
--- a/rcache.go
+++ b/rcache.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/micro/go-log"
+	log "github.com/micro/go-log"
 	"github.com/micro/go-micro/registry"
 )
 
@@ -40,8 +40,6 @@ type cache struct {
 
 var (
 	DefaultTTL = time.Minute
-
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 func backoff(attempts int) time.Duration {
@@ -305,7 +303,7 @@ func (c *cache) run(service string) {
 		}
 
 		// jitter before starting
-		j := r.Int63n(100)
+		j := rand.Int63n(100)
 		time.Sleep(time.Duration(j) * time.Millisecond)
 
 		// create new watcher
@@ -410,6 +408,7 @@ func (c *cache) String() string {
 
 // New returns a new cache
 func New(r registry.Registry, opts ...Option) Cache {
+	rand.Seed(time.Now().UnixNano())
 	options := Options{
 		TTL: DefaultTTL,
 	}


### PR DESCRIPTION
Read at 0x00c00010d500 by goroutine 95:
  math/rand.(*rngSource).Int63()
      /var/home/vtolstov/sdk/go1.12beta2/src/math/rand/rng.go:239 +0x3f
  math/rand.(*Rand).Int63n()
      /var/home/vtolstov/sdk/go1.12beta2/src/math/rand/rand.go:85 +0x8f
  github.com/micro/go-rcache.(*cache).run()
      /home/vtolstov/.cache/go-path/pkg/mod/github.com/micro/go-rcache@v0.2.1/rcache.go:308 +0x17c

Previous write at 0x00c00010d500 by goroutine 196:
  math/rand.(*rngSource).Int63()
      /var/home/vtolstov/sdk/go1.12beta2/src/math/rand/rng.go:239 +0x55
  math/rand.(*Rand).Int63n()
      /var/home/vtolstov/sdk/go1.12beta2/src/math/rand/rand.go:85 +0x8f
  github.com/micro/go-rcache.(*cache).run()
      /home/vtolstov/.cache/go-path/pkg/mod/github.com/micro/go-rcache@v0.2.1/rcache.go:308 +0x17c

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>